### PR TITLE
Add HTML table of contents feature

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -44,6 +44,21 @@
             color: {{ settings.colors.primary or '#1F6AA5' }};
             margin-top: 0;
         }
+        .toc {
+            list-style: none;
+            margin: 20px;
+            padding: 0;
+        }
+        .toc li {
+            margin-bottom: 5px;
+        }
+        .toc a {
+            color: {{ settings.colors.primary or '#1F6AA5' }};
+            text-decoration: none;
+        }
+        .toc a:hover {
+            text-decoration: underline;
+        }
         /* --- THEME STYLES INJECTED HERE --- */
         {{ theme_styles | safe }}
     </style>

--- a/templates/main_layout.html
+++ b/templates/main_layout.html
@@ -8,8 +8,18 @@
         {% endif %}
     </div>
 
+    {% if sections %}
+    <ul class="toc">
+        {% for section in sections %}
+            {% if section.title %}
+            <li><a href="#section-{{ loop.index }}">{{ section.title }}</a></li>
+            {% endif %}
+        {% endfor %}
+    </ul>
+    {% endif %}
+
     {% for section in sections %}
-        <div class="section">
+        <div class="section" id="section-{{ loop.index }}">
             {# Intelligently choose the correct template #}
             {% if 'events' in section.type %}
                 {# If the type contains 'events', use the master events partial #}


### PR DESCRIPTION
## Summary
- provide stylesheet styles for a table of contents
- generate a list of section links at the top of the bulletin
- add anchors to each section

## Testing
- `python3 -m py_compile bulletin_renderer.py main.py settings.py $(find app_core -name '*.py') $(find ui -name '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6883cfb09cdc832d899b44b469d4ee00