### PR TITLE
Add PyInstaller build support

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,4 +44,20 @@ google-generativeai
 pytest               # for tests
 pyinstaller          # for packaging
 pyupdater            # for auto‑update (optional)
-...
+
+```
+
+---
+
+## Packaging
+
+Run the build script to create a standalone executable (requires PyInstaller):
+
+```bash
+python scripts/build_exe.py
+```
+
+The resulting `bulletin_builder` directory contains an executable that can be
+distributed to users on the same platform (Windows or macOS) without needing a
+Python installation.
+

--- a/bulletin_builder.spec
+++ b/bulletin_builder.spec
@@ -1,0 +1,46 @@
+# -*- mode: python ; coding: utf-8 -*-
+import sys
+from pathlib import Path
+
+block_cipher = None
+
+a = Analysis([
+    'src/bulletin_builder/__main__.py'
+],
+    pathex=[str(Path(__file__).parent.resolve())],
+    binaries=[],
+    datas=[('src/bulletin_builder/templates', 'bulletin_builder/templates')],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+)
+
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='bulletin_builder',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    name='bulletin_builder'
+)

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ google-generativeai
 premailer
 jinja2>=3.1.2
 tkhtmlview
+pyinstaller

--- a/roadmap.json
+++ b/roadmap.json
@@ -6,7 +6,7 @@
     "acceptance": "App runs from CLI and tests still pass using new structure."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Add basic PyInstaller packaging",
     "action": "Add PyInstaller spec file and script to build a standalone executable for Windows and MacOS.",
     "acceptance": "Users can run bulletin_builder.exe without installing Python."

--- a/scripts/build_exe.py
+++ b/scripts/build_exe.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+"""Build standalone executables using PyInstaller."""
+import PyInstaller.__main__
+
+PyInstaller.__main__.run([
+    'bulletin_builder.spec',
+    '--clean',
+])


### PR DESCRIPTION
## Summary
- add packaging instructions to README
- add `pyinstaller` to requirements
- include a basic PyInstaller spec
- provide build script for cross-platform packaging
- mark PyInstaller roadmap task complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a68aa8e74832db1ac6b87ba3429aa