### PR TITLE
Implement responsive preview

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -24,7 +24,7 @@
     "acceptance": "User can browse templates visually and apply them with a click."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Responsive layout preview",
     "action": "Add toggle for desktop, tablet, and mobile preview modes within the GUI using a scaled iframe or equivalent.",
     "acceptance": "User can preview how the email/bulletin will look on different screen sizes."

--- a/src/bulletin_builder/app_core/preview.py
+++ b/src/bulletin_builder/app_core/preview.py
@@ -13,6 +13,7 @@ def init(app):
     app.update_preview      = lambda: _trigger_preview(app)
     app.toggle_preview_mode = lambda mode: _toggle_preview(app, mode)
     app.open_in_browser     = lambda: _open_in_browser(app)
+    app.set_preview_device  = lambda device: _set_preview_device(app, device)
 
 def _trigger_preview(app):
     """Start rendering in background thread when user clicks Update Preview."""
@@ -63,6 +64,7 @@ def _apply_preview(app, fut):
     else:
         raw_html, rendered = fut.result()
         mode = app.preview_mode_toggle.get()
+        device = getattr(app, 'device_mode', 'Desktop')
 
         if mode == "Rendered":
             # Try rendered → raw → code view if both fail
@@ -84,6 +86,8 @@ def _apply_preview(app, fut):
             # Code view
             app.code_preview.delete('1.0', 'end')
             app.code_preview.insert('1.0', raw_html)
+
+        _set_preview_device(app, device)
 
     # hide progress & re-enable button
     app.after(0, app._hide_progress)
@@ -107,3 +111,11 @@ def _open_in_browser(app):
     tmp.write(html.encode("utf-8"))
     tmp.close()
     webbrowser.open(tmp.name)
+
+def _set_preview_device(app, device):
+    """Adjust preview width for responsive modes."""
+    app.device_mode = device
+    widths = {"Desktop": 800, "Tablet": 600, "Mobile": 375}
+    width = widths.get(device, 800)
+    if hasattr(app, 'preview_area'):
+        app.preview_area.configure(width=width)

--- a/src/bulletin_builder/app_core/ui_setup.py
+++ b/src/bulletin_builder/app_core/ui_setup.py
@@ -99,11 +99,25 @@ def init(app):
     ctk.CTkButton(ctrl, text="Open in Browser", command=app.open_in_browser).pack(side="left", padx=5)
 
     app.preview_mode_toggle = ctk.CTkSegmentedButton(
-        ctrl, values=["Rendered","Code"], command=app.toggle_preview_mode
+        ctrl, values=["Rendered", "Code"], command=app.toggle_preview_mode
     )
     app.preview_mode_toggle.set("Rendered")
     app.preview_mode_toggle.pack(side="left", padx=5)
 
-    app.rendered_preview = HTMLLabel(prev, background="white")
-    app.code_preview     = ctk.CTkTextbox(prev, wrap="word", font=("Courier New",12))
+    app.device_mode_toggle = ctk.CTkSegmentedButton(
+        ctrl,
+        values=["Desktop", "Tablet", "Mobile"],
+        command=app.set_preview_device,
+    )
+    app.device_mode_toggle.set("Desktop")
+    app.device_mode_toggle.pack(side="left", padx=5)
+
+    app.preview_area = ctk.CTkFrame(prev)
+    app.preview_area.pack(padx=10, pady=10)
+    app.preview_area.pack_propagate(False)
+
+    app.rendered_preview = HTMLLabel(app.preview_area, background="white")
+    app.code_preview = ctk.CTkTextbox(app.preview_area, wrap="word", font=("Courier New", 12))
     # neither packed until toggle
+
+    app.set_preview_device("Desktop")


### PR DESCRIPTION
## Summary
- add responsive layout preview toggle with Desktop/Tablet/Mobile modes
- create preview container and device segmented button
- adjust preview width using new set_preview_device helper
- mark roadmap item for responsive layout preview complete

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a6ec03adc832d8c8dc7ecad2da433