### PR TITLE
Implement sheet & CSV import for announcements

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -42,7 +42,7 @@
     "acceptance": "User can download a valid .ics file matching event details entered."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Google Sheets & CSV integration for announcements",
     "action": "Allow loading tabular event data from Google Sheets or CSV files to auto-generate content blocks.",
     "acceptance": "User can generate bulletins from structured sheet rows with minimal input."

--- a/src/bulletin_builder/app_core/importer.py
+++ b/src/bulletin_builder/app_core/importer.py
@@ -1,0 +1,60 @@
+import csv
+import io
+import urllib.request
+from tkinter import filedialog, messagebox, simpledialog
+
+
+def init(app):
+    """Attach CSV/Google Sheets import handlers onto app."""
+
+    def _rows_to_sections(rows):
+        count = 0
+        for row in rows:
+            if not any(row.values()):
+                continue
+            app.sections_data.append({
+                'title': row.get('title', '').strip(),
+                'type': 'announcements',
+                'body': row.get('body', '').strip(),
+                'link': row.get('link', '').strip(),
+                'link_text': row.get('link_text', '').strip(),
+            })
+            count += 1
+        if count:
+            app.refresh_listbox_titles()
+            app.show_placeholder()
+            app.update_preview()
+            app.show_status_message(f"Imported {count} announcements")
+
+    def import_csv_file():
+        path = filedialog.askopenfilename(
+            defaultextension='.csv', filetypes=[('CSV Files','*.csv')],
+            initialdir='.', title='Import Announcements CSV'
+        )
+        if not path:
+            return
+        try:
+            with open(path, newline='', encoding='utf-8') as f:
+                reader = csv.DictReader(f)
+                rows = list(reader)
+        except Exception as e:
+            messagebox.showerror('Import Error', str(e))
+            return
+        _rows_to_sections(rows)
+
+    def import_google_sheet():
+        url = simpledialog.askstring('Google Sheet URL', 'Enter public CSV URL:')
+        if not url:
+            return
+        try:
+            with urllib.request.urlopen(url) as resp:
+                text = resp.read().decode('utf-8')
+            reader = csv.DictReader(io.StringIO(text))
+            rows = list(reader)
+        except Exception as e:
+            messagebox.showerror('Import Error', str(e))
+            return
+        _rows_to_sections(rows)
+
+    app.import_announcements_csv = import_csv_file
+    app.import_announcements_sheet = import_google_sheet

--- a/src/bulletin_builder/app_core/loader.py
+++ b/src/bulletin_builder/app_core/loader.py
@@ -15,8 +15,8 @@ def init_app(app):
     except Exception as e:
         print(f"Error in core_init: {e}")
 
-    # 2) then drafts, handlers, sections, exporter, preview...
-    for module in ("handlers", "drafts", "sections", "exporter", "preview", "ui_setup"):
+    # 2) then drafts, handlers, sections, exporter, preview, importer...
+    for module in ("handlers", "drafts", "sections", "exporter", "preview", "importer", "ui_setup"):
         try:
             m = importlib.import_module(f"{base_pkg}.{module}")
             if hasattr(m, "init"):

--- a/src/bulletin_builder/app_core/ui_setup.py
+++ b/src/bulletin_builder/app_core/ui_setup.py
@@ -28,6 +28,9 @@ def init(app):
     tools_menu = tk.Menu(menubar, tearoff=0)
     tools_menu.add_command(label="WYSIWYG Editor", command=app.open_wysiwyg_editor)
     tools_menu.add_command(label="Template Gallery", command=app.open_template_gallery)
+    tools_menu.add_separator()
+    tools_menu.add_command(label="Import Announcements CSV...", command=app.import_announcements_csv)
+    tools_menu.add_command(label="Import Announcements from Sheet...", command=app.import_announcements_sheet)
     menubar.add_cascade(label="Tools", menu=tools_menu)
 
     app.config(menu=menubar)


### PR DESCRIPTION
## Summary
- import announcements from CSV or Google Sheets
- expose import actions to the Tools menu
- load importer module during app initialization
- update roadmap

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a8f2e4a0c832dbfea011d4c23090c