### PR TITLE
Implement dark mode toggle

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -48,7 +48,7 @@
     "acceptance": "User can generate bulletins from structured sheet rows with minimal input."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Dark mode editor theme toggle",
     "action": "Add a toggle in the GUI to switch between light and dark editing modes for eye comfort.",
     "acceptance": "GUI theme updates dynamically when toggled."

--- a/src/bulletin_builder/app_core/drafts.py
+++ b/src/bulletin_builder/app_core/drafts.py
@@ -9,6 +9,7 @@ def init(app):
             'bulletin_title': 'LACC Bulletin',
             'bulletin_date': date.today().strftime('%A, %B %d, %Y'),
             'theme_css': 'default.css',
+            'appearance_mode': 'Dark',
             'colors': {'primary':'#103040','secondary':'#506070'},
             'google_api_key': app.google_api_key
         }

--- a/src/bulletin_builder/settings.py
+++ b/src/bulletin_builder/settings.py
@@ -13,6 +13,7 @@ class Settings:
     })
     template_path: str = str(Path(__file__).resolve().parent / "templates")
     theme_css: Optional[str] = None  # e.g. "club_theme.css"
+    appearance_mode: str = "Dark"
 
     @property
     def jinja_env(self) -> Environment:

--- a/src/bulletin_builder/ui/settings.py
+++ b/src/bulletin_builder/ui/settings.py
@@ -51,6 +51,21 @@ class SettingsFrame(ctk.CTkFrame):
         self.google_api_entry = ctk.CTkEntry(self, show="*")
         self.google_api_entry.grid(row=5, column=1, sticky="ew", pady=(0,5))
 
+        # Appearance Mode
+        ctk.CTkLabel(self, text="Appearance:").grid(row=6, column=0, sticky="w", pady=(0,5))
+        self.appearance_option = ctk.CTkOptionMenu(
+            self,
+            values=["Light", "Dark"],
+            command=self._on_appearance_changed,
+        )
+        # initialize with current mode
+        try:
+            current = ctk.get_appearance_mode()
+        except Exception:
+            current = "Dark"
+        self.appearance_option.set(current)
+        self.appearance_option.grid(row=6, column=1, sticky="ew", pady=(0,5))
+
         self.grid_columnconfigure(1, weight=1)
 
     def load_data(self, settings_data: dict, api_key: str):
@@ -74,6 +89,18 @@ class SettingsFrame(ctk.CTkFrame):
         theme = settings_data.get("theme_css", self.themes[0] if self.themes else "default.css")
         if theme in self.themes:
             self.theme_menu.set(theme)
+
+        # Appearance Mode
+        try:
+            current_mode = ctk.get_appearance_mode()
+        except Exception:
+            current_mode = "Dark"
+        appearance = settings_data.get("appearance_mode", current_mode)
+        try:
+            ctk.set_appearance_mode(appearance)
+        except Exception:
+            pass
+        self.appearance_option.set(appearance)
 
         # Colors
         self.primary_color_entry.delete(0, "end")
@@ -100,4 +127,12 @@ class SettingsFrame(ctk.CTkFrame):
                 "secondary": self.secondary_color_entry.get(),
             },
             "google_api_key": self.google_api_entry.get(),
+            "appearance_mode": self.appearance_option.get(),
         }
+
+    def _on_appearance_changed(self, mode: str):
+        """Apply the selected appearance mode immediately."""
+        try:
+            ctk.set_appearance_mode(mode)
+        except Exception:
+            pass


### PR DESCRIPTION
## Summary
- add appearance mode option in settings UI
- persist appearance preference in drafts and settings
- include appearance mode in default settings dataclass
- update roadmap

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688a91579184832db5cdb7cfe336e2f9