### PR TITLE
Implement SMTP preview email

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,11 @@
 
 - Add / remove / reorder sections  
 - Preview in‑app (HTML via `tkhtmlview`) or open browser  
-- Export to PDF via WeasyPrint  
-- Copy email‑ready HTML to clipboard  
-- Pluggable “sections” architecture for custom text, events, images, announcements  
-- Themeable: pick CSS file, colors, title/date, Google AI key integration  
+- Export to PDF via WeasyPrint
+- Copy email‑ready HTML to clipboard
+- Send preview emails via configurable SMTP server
+- Pluggable “sections” architecture for custom text, events, images, announcements
+- Themeable: pick CSS file, colors, title/date, Google AI key integration
 
 ---
 
@@ -60,4 +61,22 @@ python scripts/build_exe.py
 The resulting `bulletin_builder` directory contains an executable that can be
 distributed to users on the same platform (Windows or macOS) without needing a
 Python installation.
+
+### SMTP Configuration
+
+To use the **Send Test Email** feature, update `config.ini` with your SMTP
+credentials:
+
+```ini
+[smtp]
+host = "smtp.example.com"
+port = 587
+username = "your_username"
+password = "your_password"
+from_addr = "Bulletin Builder <user@example.com>"
+use_tls = true
+```
+
+After configuring, click **Send Test Email...** in the app and enter the
+destination address to receive a preview message.
 

--- a/config.ini
+++ b/config.ini
@@ -4,3 +4,11 @@ google_api_key = "REPLACE ME WITH YOUR GOOGLE AI API KEY"
 [google]
 api_key = "REPLACE ME WITH YOUR GOOGLE AI API KEY"
 
+[smtp]
+host = "smtp.example.com"
+port = 587
+username = "your_username"
+password = "your_password"
+from_addr = "Bulletin Builder <user@example.com>"
+use_tls = true
+

--- a/roadmap.json
+++ b/roadmap.json
@@ -54,7 +54,7 @@
     "acceptance": "GUI theme updates dynamically when toggled."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "One-click email preview & test send",
     "action": "Integrate a basic SMTP client to allow previewing bulletins by sending them to an email address.",
     "acceptance": "User can enter their email and receive the bulletin in their inbox as a test."

--- a/src/bulletin_builder/app_core/exporter.py
+++ b/src/bulletin_builder/app_core/exporter.py
@@ -3,11 +3,17 @@
 import tempfile
 import webbrowser
 from pathlib import Path
-from tkinter import filedialog
+from tkinter import filedialog, messagebox
 from uuid import uuid4
 from datetime import datetime
 
+import configparser
+import os
+import smtplib
+from email.message import EmailMessage
+
 from ..ui.calendar_event_dialog import CalendarEventDialog
+from ..ui.email_dialog import EmailDialog
 
 from premailer import transform
 from weasyprint import HTML
@@ -132,3 +138,67 @@ def init(app):
         return "\n".join(lines)
 
     app.on_export_ics_clicked = on_export_ics_clicked
+
+    # --- Send test email (threaded) ---
+    def on_send_test_email_clicked():
+        dlg = EmailDialog(app)
+        to_addr = dlg.get_email()
+        if not to_addr:
+            return
+        app.export_button.configure(state="disabled")
+        app.email_button.configure(state="disabled")
+        app.send_test_button.configure(state="disabled")
+        app._show_progress("Sending email…")
+        future = app._thread_executor.submit(_do_send_email, to_addr)
+        future.add_done_callback(_on_send_email_done)
+
+    def _load_smtp_config():
+        cfg = configparser.ConfigParser()
+        if os.path.exists("config.ini"):
+            cfg.read("config.ini")
+            return cfg.get("smtp", {})
+        return {}
+
+    def _do_send_email(to_addr: str):
+        settings = app.settings_frame.dump()
+        html = app.renderer.render_html(app.sections_data, settings)
+        html = transform(html)
+
+        smtp_cfg = _load_smtp_config()
+        host = smtp_cfg.get("host", "localhost")
+        port = int(smtp_cfg.get("port", 25))
+        username = smtp_cfg.get("username", "")
+        password = smtp_cfg.get("password", "")
+        from_addr = smtp_cfg.get("from_addr", username or "")
+        use_tls = str(smtp_cfg.get("use_tls", "true")).lower() == "true"
+
+        msg = EmailMessage()
+        msg["Subject"] = f"Preview: {settings.get('bulletin_title', 'Bulletin')}"
+        msg["From"] = from_addr
+        msg["To"] = to_addr
+        msg.set_content("HTML preview attached.")
+        msg.add_alternative(html, subtype="html")
+
+        with smtplib.SMTP(host, port) as s:
+            if use_tls:
+                try:
+                    s.starttls()
+                except Exception:
+                    pass
+            if username:
+                s.login(username, password)
+            s.send_message(msg)
+
+    def _on_send_email_done(fut):
+        try:
+            fut.result()
+            app.after(0, lambda: app.show_status_message("Test email sent!"))
+        except Exception as e:
+            app.after(0, lambda: messagebox.showerror("Email Error", str(e)))
+        finally:
+            app.after(0, app._hide_progress)
+            app.after(0, lambda: app.export_button.configure(state="normal"))
+            app.after(0, lambda: app.email_button.configure(state="normal"))
+            app.after(0, lambda: app.send_test_button.configure(state="normal"))
+
+    app.on_send_test_email_clicked = on_send_test_email_clicked

--- a/src/bulletin_builder/app_core/ui_setup.py
+++ b/src/bulletin_builder/app_core/ui_setup.py
@@ -72,6 +72,8 @@ def init(app):
     expf.pack(fill="x", pady=5)
     app.email_button = ctk.CTkButton(expf, text="Copy for Email", command=app.on_copy_for_email_clicked)
     app.email_button.pack(fill="x", pady=(0,5))
+    app.send_test_button = ctk.CTkButton(expf, text="Send Test Email...", command=app.on_send_test_email_clicked)
+    app.send_test_button.pack(fill="x", pady=(0,5))
     app.export_button = ctk.CTkButton(expf, text="Export to PDF...", command=app.on_export_pdf_clicked)
     app.export_button.pack(fill="x", pady=(0,5))
     app.ics_button = ctk.CTkButton(expf, text="Export Event .ics", command=app.on_export_ics_clicked)

--- a/src/bulletin_builder/ui/email_dialog.py
+++ b/src/bulletin_builder/ui/email_dialog.py
@@ -1,0 +1,47 @@
+import customtkinter as ctk
+import tkinter as tk
+
+class EmailDialog(ctk.CTkToplevel):
+    """Dialog to capture a destination email address."""
+
+    def __init__(self, parent):
+        super().__init__(parent)
+        self.title("Send Test Email")
+        self.geometry("400x160")
+        self.transient(parent)
+        self.grab_set()
+        self.result = None
+
+        frm = ctk.CTkFrame(self)
+        frm.pack(expand=True, fill="both", padx=20, pady=20)
+
+        ctk.CTkLabel(frm, text="Send preview to:").pack(anchor="w")
+        self.email_entry = ctk.CTkEntry(frm)
+        self.email_entry.pack(fill="x", pady=(0, 20))
+
+        btnf = ctk.CTkFrame(frm)
+        btnf.pack(fill="x", side="bottom")
+        ctk.CTkButton(btnf, text="Send", command=self.on_ok).pack(side="right")
+        ctk.CTkButton(
+            btnf,
+            text="Cancel",
+            command=self.destroy,
+            fg_color="gray50",
+            hover_color="gray40",
+        ).pack(side="right", padx=(0, 10))
+
+        self.email_entry.focus_set()
+        self.wait_window()
+
+    def on_ok(self):
+        addr = self.email_entry.get().strip()
+        if not addr:
+            tk.messagebox.showwarning(
+                "Input Error", "Please enter an email address.", parent=self
+            )
+            return
+        self.result = addr
+        self.destroy()
+
+    def get_email(self):
+        return self.result


### PR DESCRIPTION
## Summary
- add Send Test Email button and dialog
- integrate SMTP client to send preview using config settings
- document SMTP configuration in README
- add SMTP settings example to config.ini
- mark roadmap task for email preview as complete

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688a944c9788832d9fc915364db8debb