### PR TITLE
Implement keyboard shortcuts

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 - [Requirements](#requirements)  
 - [Installation](#installation)  
 - [Usage](#usage)  
-- [Packaging](#packaging)  
-- [Auto‑Update](#auto‑update)  
-- [Testing](#testing)  
+- [Packaging](#packaging)
+- [Auto‑Update](#auto‑update)
+- [Keyboard Shortcuts](#keyboard-shortcuts)
+- [Testing](#testing)
 - [Contributing](#contributing)  
 - [License](#license)  
 
@@ -80,4 +81,18 @@ use_tls = true
 
 After configuring, click **Send Test Email...** in the app and enter the
 destination address to receive a preview message.
+
+## Keyboard Shortcuts
+
+Common actions can be triggered from the keyboard:
+
+| Shortcut | Action |
+| -------- | ------ |
+| `Ctrl+N` | New draft |
+| `Ctrl+O` | Open draft |
+| `Ctrl+S` | Save draft |
+| `Ctrl+Shift+S` | Save draft as... |
+| `Ctrl+Z` | Undo (WYSIWYG editor) |
+| `Ctrl+Y` | Redo (WYSIWYG editor) |
+| `Ctrl+E` | Export HTML (WYSIWYG editor) |
 

--- a/roadmap.json
+++ b/roadmap.json
@@ -90,7 +90,7 @@
     "acceptance": "Both HTML and text versions are exported and styled appropriately."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Keyboard shortcut support",
     "action": "Add keyboard navigation for power users: e.g., Ctrl+S to save, Ctrl+Z to undo, etc.",
     "acceptance": "Documented shortcuts work reliably in the editor interface."

--- a/src/bulletin_builder/app_core/ui_setup.py
+++ b/src/bulletin_builder/app_core/ui_setup.py
@@ -132,3 +132,10 @@ def init(app):
     # neither packed until toggle
 
     app.set_preview_device("Desktop")
+
+    # --- Keyboard Shortcuts ---
+    app.bind("<Control-s>", lambda e: app.save_draft())
+    app.bind("<Control-S>", lambda e: app.save_draft())  # for some platforms
+    app.bind("<Control-Shift-S>", lambda e: app.save_draft(save_as=True))
+    app.bind("<Control-o>", lambda e: app.open_draft())
+    app.bind("<Control-n>", lambda e: app.new_draft())

--- a/src/bulletin_builder/wysiwyg_editor.py
+++ b/src/bulletin_builder/wysiwyg_editor.py
@@ -17,6 +17,11 @@ class WysiwygEditor(ctk.CTkToplevel):
         self.title("WYSIWYG Editor")
         self.geometry("800x600")
 
+        # Keyboard shortcuts
+        self.bind("<Control-z>", lambda e: self.undo())
+        self.bind("<Control-y>", lambda e: self.redo())
+        self.bind("<Control-e>", lambda e: self.export_html())
+
         self.canvas = tk.Canvas(self, bg="white")
         self.canvas.pack(side="left", fill="both", expand=True)
 


### PR DESCRIPTION
## Summary
- implement save/open/new shortcuts in the main UI
- add undo/redo/export shortcuts in the WYSIWYG editor
- document available shortcuts in README
- mark *Keyboard shortcut support* roadmap item complete

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa3966464832db485041883f0df15