### PR TITLE
Implement community events feed importer

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -102,7 +102,7 @@
     "acceptance": "Sidebar shows list of actions with timestamps as user makes changes."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Add Community Events Feed Integration",
     "action": "Add a module to fetch event data (title, date, time, image) from a remote source like Google Sheets, JSON API, or WebCal.",
     "acceptance": "User can import events from a public URL or connected sheet and preview them in the bulletin builder."

--- a/src/bulletin_builder/app_core/importer.py
+++ b/src/bulletin_builder/app_core/importer.py
@@ -3,6 +3,8 @@ import io
 import urllib.request
 from tkinter import filedialog, messagebox, simpledialog
 
+from ..event_feed import fetch_events
+
 
 def init(app):
     """Attach CSV/Google Sheets import handlers onto app."""
@@ -56,5 +58,29 @@ def init(app):
             return
         _rows_to_sections(rows)
 
+    def import_events_feed():
+        url = simpledialog.askstring('Events Feed URL', 'Enter events JSON/CSV URL:')
+        if not url:
+            return
+        try:
+            events = fetch_events(url)
+        except Exception as e:
+            messagebox.showerror('Import Error', str(e))
+            return
+        if not events:
+            messagebox.showinfo('Import Events', 'No events found.')
+            return
+        app.sections_data.append({
+            'title': 'Community Events',
+            'type': 'community_events',
+            'content': events,
+            'layout_style': 'Card'
+        })
+        app.refresh_listbox_titles()
+        app.show_placeholder()
+        app.update_preview()
+        app.show_status_message(f"Imported {len(events)} events")
+
     app.import_announcements_csv = import_csv_file
     app.import_announcements_sheet = import_google_sheet
+    app.import_events_feed = import_events_feed

--- a/src/bulletin_builder/app_core/ui_setup.py
+++ b/src/bulletin_builder/app_core/ui_setup.py
@@ -32,6 +32,7 @@ def init(app):
     tools_menu.add_separator()
     tools_menu.add_command(label="Import Announcements CSV...", command=app.import_announcements_csv)
     tools_menu.add_command(label="Import Announcements from Sheet...", command=app.import_announcements_sheet)
+    tools_menu.add_command(label="Import Events Feed...", command=app.import_events_feed)
     menubar.add_cascade(label="Tools", menu=tools_menu)
 
     app.config(menu=menubar)

--- a/src/bulletin_builder/event_feed.py
+++ b/src/bulletin_builder/event_feed.py
@@ -1,0 +1,47 @@
+import csv
+import io
+import json
+import urllib.request
+from typing import List, Dict
+
+
+def fetch_events(url: str) -> List[Dict[str, str]]:
+    """Fetch events from a JSON or CSV URL.
+
+    Args:
+        url: Public URL returning JSON or CSV rows with columns like
+            title/description, date, time, image or image_url.
+
+    Returns:
+        A list of event dictionaries with ``date``, ``time``, ``description`` and
+        ``image_url`` keys.
+    """
+    with urllib.request.urlopen(url) as resp:
+        text = resp.read().decode("utf-8")
+
+    events: List[Dict[str, str]] = []
+    try:
+        data = json.loads(text)
+        if isinstance(data, dict):
+            data = data.get("events", []) or data.get("items", [])
+        for item in data:
+            events.append(
+                {
+                    "date": item.get("date", ""),
+                    "time": item.get("time", ""),
+                    "description": item.get("title") or item.get("description", ""),
+                    "image_url": item.get("image") or item.get("image_url", ""),
+                }
+            )
+    except json.JSONDecodeError:
+        reader = csv.DictReader(io.StringIO(text))
+        for row in reader:
+            events.append(
+                {
+                    "date": row.get("date", ""),
+                    "time": row.get("time", ""),
+                    "description": row.get("title") or row.get("description", ""),
+                    "image_url": row.get("image") or row.get("image_url", ""),
+                }
+            )
+    return [e for e in events if any(e.values())]


### PR DESCRIPTION
## Summary
- add `fetch_events` utility for pulling event data from JSON/CSV URLs
- allow importing events feed through importer module and tools menu
- update roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688aa6e477a8832d812e07ca81fe12b7