### PR TITLE
Implement event block generation

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -108,7 +108,7 @@
     "acceptance": "User can import events from a public URL or connected sheet and preview them in the bulletin builder."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Auto-Generate Event Blocks from Feed",
     "action": "Parse each fetched event into a styled content block and insert them with default formatting (e.g., header, image, time).",
     "acceptance": "User can see cleanly formatted event blocks added automatically and can edit them if needed."

--- a/src/bulletin_builder/app_core/importer.py
+++ b/src/bulletin_builder/app_core/importer.py
@@ -3,7 +3,7 @@ import io
 import urllib.request
 from tkinter import filedialog, messagebox, simpledialog
 
-from ..event_feed import fetch_events
+from ..event_feed import fetch_events, events_to_blocks
 
 
 def init(app):
@@ -63,10 +63,11 @@ def init(app):
         if not url:
             return
         try:
-            events = fetch_events(url)
+            raw_events = fetch_events(url)
         except Exception as e:
             messagebox.showerror('Import Error', str(e))
             return
+        events = events_to_blocks(raw_events)
         if not events:
             messagebox.showinfo('Import Events', 'No events found.')
             return

--- a/src/bulletin_builder/event_feed.py
+++ b/src/bulletin_builder/event_feed.py
@@ -45,3 +45,23 @@ def fetch_events(url: str) -> List[Dict[str, str]]:
                 }
             )
     return [e for e in events if any(e.values())]
+
+
+def events_to_blocks(events: List[Dict[str, str]]) -> List[Dict[str, str]]:
+    """Convert raw event dictionaries into standard bulletin blocks.
+
+    Each returned block is guaranteed to have ``date``, ``time``, ``description``
+    and ``image_url`` keys so templates can render them without additional
+    checks.
+    """
+    blocks: List[Dict[str, str]] = []
+    for ev in events:
+        blocks.append(
+            {
+                "date": (ev.get("date") or "").strip(),
+                "time": (ev.get("time") or "").strip(),
+                "description": (ev.get("description") or ev.get("title") or "").strip(),
+                "image_url": (ev.get("image_url") or ev.get("image") or "").strip(),
+            }
+        )
+    return blocks


### PR DESCRIPTION
## Summary
- normalize events from feeds into renderable blocks
- create events section using those blocks during import
- update roadmap

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688aa8d37d34832daebf42ae4f5c04ad