### PR TITLE
Implement Smart Suggestions Panel

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -126,7 +126,7 @@
     "acceptance": "All event images appear uniform and do not distort the bulletin layout."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Add ‘Smart Suggestions’ Panel",
     "action": "Analyze recent bulletin content and suggest block types (e.g., if many events: suggest adding a 'Community Highlights' banner).",
     "acceptance": "User receives real-time layout suggestions based on bulletin content and patterns."

--- a/src/bulletin_builder/app_core/loader.py
+++ b/src/bulletin_builder/app_core/loader.py
@@ -15,8 +15,18 @@ def init_app(app):
     except Exception as e:
         print(f"Error in core_init: {e}")
 
-    # 2) then drafts, handlers, sections, components, exporter, preview, importer...
-    for module in ("handlers", "drafts", "sections", "component_library", "exporter", "preview", "importer", "ui_setup"):
+    # 2) then drafts, handlers, sections, components, exporter, preview, suggestions, importer...
+    for module in (
+        "handlers",
+        "drafts",
+        "sections",
+        "component_library",
+        "exporter",
+        "preview",
+        "suggestions",
+        "importer",
+        "ui_setup",
+    ):
         try:
             m = importlib.import_module(f"{base_pkg}.{module}")
             if hasattr(m, "init"):

--- a/src/bulletin_builder/app_core/sections.py
+++ b/src/bulletin_builder/app_core/sections.py
@@ -99,6 +99,8 @@ def init(app):
             app.section_listbox.insert(tk.END, f"{i+1}. {title}")
         for idx in sel:
             app.section_listbox.selection_set(idx)
+        if hasattr(app, 'compute_suggestions'):
+            app.compute_suggestions()
 
     # Bind methods
     app.add_section_dialog = add_section_dialog

--- a/src/bulletin_builder/app_core/suggestions.py
+++ b/src/bulletin_builder/app_core/suggestions.py
@@ -1,0 +1,68 @@
+import customtkinter as ctk
+import tkinter as tk
+
+
+def init(app):
+    """Attach smart suggestion helpers to the application."""
+
+    def build_panel(parent):
+        frame = ctk.CTkFrame(parent)
+        ctk.CTkLabel(frame, text="Smart Suggestions").pack(anchor="w")
+        listbox = tk.Listbox(
+            frame,
+            bg="#2B2B2B",
+            fg="white",
+            selectbackground="#1F6AA5",
+            selectforeground="white",
+            borderwidth=0,
+            highlightthickness=0,
+            height=5,
+            font=("Roboto", 10),
+        )
+        listbox.pack(fill="both", expand=True, pady=(5, 0))
+        listbox.bind("<Double-Button-1>", apply_suggestion)
+        app.suggestions_list = listbox
+        return frame
+
+    def compute_suggestions():
+        suggestions = []
+        events_sections = [
+            sec
+            for sec in app.sections_data
+            if sec.get("type") in ("events", "lacc_events", "community_events")
+        ]
+        total_events = sum(len(sec.get("content", [])) for sec in events_sections)
+        has_highlights = any(
+            "Community Highlights" in sec.get("title", "") for sec in app.sections_data
+        )
+        if total_events >= 5 and not has_highlights:
+            suggestions.append("Add a 'Community Highlights' banner")
+        if not suggestions:
+            suggestions.append("No suggestions")
+        app.suggestions_list.delete(0, tk.END)
+        for s in suggestions:
+            app.suggestions_list.insert(tk.END, s)
+
+    def apply_suggestion(event=None):
+        sel = app.suggestions_list.curselection()
+        if not sel:
+            return
+        suggestion = app.suggestions_list.get(sel[0])
+        if "Community Highlights" in suggestion:
+            app.sections_data.append(
+                {
+                    "title": "Community Highlights",
+                    "type": "announcements",
+                    "body": "Highlight key upcoming events here.",
+                    "link": "",
+                    "link_text": "",
+                }
+            )
+            app.refresh_listbox_titles()
+            app.show_placeholder()
+            app.update_preview()
+        compute_suggestions()
+
+    app.compute_suggestions = compute_suggestions
+    app.apply_suggestion = apply_suggestion
+    app.build_suggestions_panel = build_panel

--- a/src/bulletin_builder/app_core/ui_setup.py
+++ b/src/bulletin_builder/app_core/ui_setup.py
@@ -83,6 +83,10 @@ def init(app):
     app.ics_button = ctk.CTkButton(expf, text="Export Event .ics", command=app.on_export_ics_clicked)
     app.ics_button.pack(fill="x")
 
+    # Smart Suggestions Panel
+    sugg_frame = app.build_suggestions_panel(lp)
+    sugg_frame.pack(fill="x", pady=5)
+
     # Right panel: editor or placeholder
     app.right_panel = ctk.CTkFrame(content)
     app.right_panel.grid(row=0, column=1, sticky="nsew", padx=10, pady=10)
@@ -140,3 +144,6 @@ def init(app):
     app.bind("<Control-Shift-S>", lambda e: app.save_draft(save_as=True))
     app.bind("<Control-o>", lambda e: app.open_draft())
     app.bind("<Control-n>", lambda e: app.new_draft())
+
+    if hasattr(app, "compute_suggestions"):
+        app.compute_suggestions()


### PR DESCRIPTION
## Summary
- add a new `suggestions` module providing smart layout suggestions
- hook suggestions module into loader and UI
- display suggestions panel in the Content tab
- refresh suggestions when sections change
- update roadmap task status to complete

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688aafcd4148832d91441b6282d00d64