### PR TITLE
Implement calendar feed auto-sync

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -15,3 +15,6 @@ password = "your_password"
 from_addr = "Bulletin Builder <user@example.com>"
 use_tls = true
 
+[events]
+feed_url = "https://example.com/events.json"
+

--- a/roadmap.json
+++ b/roadmap.json
@@ -132,7 +132,7 @@
     "acceptance": "User receives real-time layout suggestions based on bulletin content and patterns."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Link Event Feed to Admin Calendar",
     "action": "Enable auto-sync from community calendars like Google Calendar, Airtable, or a JSON endpoint (e.g., lakealmanorcountryclub.com/data/events.json).",
     "acceptance": "Events can be imported and previewed from a connected calendar feed with minimal setup."

--- a/src/bulletin_builder/__main__.py
+++ b/src/bulletin_builder/__main__.py
@@ -1,7 +1,11 @@
 import os
 import customtkinter as ctk
 from .app_core.loader import init_app
-from .app_core.config import save_api_key, save_openai_key
+from .app_core.config import (
+    save_api_key,
+    save_openai_key,
+    save_events_feed_url,
+)
 import argparse
 from .wysiwyg_editor import launch_gui
 
@@ -12,9 +16,10 @@ class BulletinBuilderApp(ctk.CTk):
     """
     def __init__(self):
         super().__init__()
-        # Expose API key savers for SettingsFrame
+        # Expose config savers for SettingsFrame
         self.save_api_key_to_config = save_api_key
         self.save_openai_key_to_config = save_openai_key
+        self.save_events_url_to_config = save_events_feed_url
 
         # Wire up all subsystems (core_init, handlers, drafts, sections, exporter, preview, UI)
         init_app(self)

--- a/src/bulletin_builder/app_core/config.py
+++ b/src/bulletin_builder/app_core/config.py
@@ -49,3 +49,22 @@ def load_openai_key() -> str:
 
 def save_openai_key(api_key: str) -> None:
     _save_key("openai", api_key)
+
+
+def load_events_feed_url() -> str:
+    config = configparser.ConfigParser()
+    if os.path.exists(CONFIG_FILE):
+        config.read(CONFIG_FILE)
+        return config.get("events", "feed_url", fallback="")
+    return ""
+
+
+def save_events_feed_url(url: str) -> None:
+    config = configparser.ConfigParser()
+    if os.path.exists(CONFIG_FILE):
+        config.read(CONFIG_FILE)
+    if "events" not in config:
+        config["events"] = {}
+    config["events"]["feed_url"] = url
+    with open(CONFIG_FILE, "w") as f:
+        config.write(f)

--- a/src/bulletin_builder/app_core/core_init.py
+++ b/src/bulletin_builder/app_core/core_init.py
@@ -11,6 +11,7 @@ from ..bulletin_renderer import BulletinRenderer
 from .config import (
     load_api_key,
     load_openai_key,
+    load_events_feed_url,
 )
 from ..ui.base_section import SectionRegistry
 
@@ -35,6 +36,7 @@ def init(app):
     # --- load & configure AI keys ---
     app.google_api_key = load_api_key()
     app.openai_api_key = load_openai_key()
+    app.events_feed_url = load_events_feed_url()
     genai.configure(api_key=app.google_api_key)
 
     # Configure OpenAI when key available

--- a/src/bulletin_builder/app_core/drafts.py
+++ b/src/bulletin_builder/app_core/drafts.py
@@ -11,7 +11,8 @@ def init(app):
             'theme_css': 'default.css',
             'appearance_mode': 'Dark',
             'colors': {'primary':'#103040','secondary':'#506070'},
-            'google_api_key': app.google_api_key
+            'google_api_key': app.google_api_key,
+            'events_feed_url': app.events_feed_url
         }
 
     def new_draft():
@@ -19,7 +20,12 @@ def init(app):
             app.sections_data.clear()
             app.current_draft_path = None
             if hasattr(app.settings_frame,'load_data'):
-                app.settings_frame.load_data(_default_settings(), app.google_api_key, app.openai_api_key)
+                app.settings_frame.load_data(
+                    _default_settings(),
+                    app.google_api_key,
+                    app.openai_api_key,
+                    app.events_feed_url,
+                )
             app.renderer.set_template('main_layout.html')
             app.refresh_listbox_titles()
             app.show_placeholder()
@@ -42,7 +48,8 @@ def init(app):
             app.settings_frame.load_data(
                 settings,
                 settings.get('google_api_key', app.google_api_key),
-                settings.get('openai_api_key', app.openai_api_key)
+                settings.get('openai_api_key', app.openai_api_key),
+                settings.get('events_feed_url', app.events_feed_url),
             )
         app.refresh_listbox_titles()
         app.show_placeholder()

--- a/src/bulletin_builder/app_core/importer.py
+++ b/src/bulletin_builder/app_core/importer.py
@@ -58,8 +58,9 @@ def init(app):
             return
         _rows_to_sections(rows)
 
-    def import_events_feed():
-        url = simpledialog.askstring('Events Feed URL', 'Enter events JSON/CSV URL:')
+    def import_events_feed(url: str | None = None):
+        if not url:
+            url = simpledialog.askstring('Events Feed URL', 'Enter events JSON/CSV URL:')
         if not url:
             return
         try:
@@ -83,6 +84,17 @@ def init(app):
         app.update_preview()
         app.show_status_message(f"Imported {len(events)} events")
 
+    def auto_sync_events_feed():
+        url = getattr(app, 'events_feed_url', '')
+        if not url:
+            return
+        import_events_feed(url)
+
+
     app.import_announcements_csv = import_csv_file
     app.import_announcements_sheet = import_google_sheet
     app.import_events_feed = import_events_feed
+    app.auto_sync_events_feed = auto_sync_events_feed
+
+    # Auto sync on startup if URL configured
+    app.auto_sync_events_feed()

--- a/src/bulletin_builder/app_core/ui_setup.py
+++ b/src/bulletin_builder/app_core/ui_setup.py
@@ -99,10 +99,11 @@ def init(app):
         refresh_callback=app.refresh_listbox_titles,
         save_api_key_callback=app.save_api_key_to_config,
         save_openai_key_callback=app.save_openai_key_to_config,
+        save_events_url_callback=app.save_events_url_to_config,
     )
     app.settings_frame.pack(fill="both", expand=True, padx=10, pady=10)
     # Load defaults + persisted API key on startup
-    app.settings_frame.load_data({}, app.google_api_key, app.openai_api_key)
+    app.settings_frame.load_data({}, app.google_api_key, app.openai_api_key, app.events_feed_url)
 
     # --- Preview Tab ---
     prev = app.tab_view.tab("Preview")

--- a/src/bulletin_builder/ui/settings.py
+++ b/src/bulletin_builder/ui/settings.py
@@ -12,11 +12,12 @@ class SettingsFrame(ctk.CTkFrame):
       • Google AI API Key
     """
 
-    def __init__(self, parent, refresh_callback: callable, save_api_key_callback: callable, save_openai_key_callback: callable):
+    def __init__(self, parent, refresh_callback: callable, save_api_key_callback: callable, save_openai_key_callback: callable, save_events_url_callback: callable):
         super().__init__(parent, fg_color="transparent")
         self.refresh_callback = refresh_callback
         self.save_api_key_callback = save_api_key_callback
         self.save_openai_key_callback = save_openai_key_callback
+        self.save_events_url_callback = save_events_url_callback
 
         # Build all controls
         self._build_widgets()
@@ -60,8 +61,12 @@ class SettingsFrame(ctk.CTkFrame):
         self.openai_api_entry = ctk.CTkEntry(self, show="*")
         self.openai_api_entry.grid(row=6, column=1, sticky="ew", pady=(0,5))
 
+        ctk.CTkLabel(self, text="Events Feed URL:").grid(row=7, column=0, sticky="w", pady=(0,5))
+        self.events_feed_entry = ctk.CTkEntry(self)
+        self.events_feed_entry.grid(row=7, column=1, sticky="ew", pady=(0,5))
+
         # Appearance Mode
-        ctk.CTkLabel(self, text="Appearance:").grid(row=7, column=0, sticky="w", pady=(0,5))
+        ctk.CTkLabel(self, text="Appearance:").grid(row=8, column=0, sticky="w", pady=(0,5))
         self.appearance_option = ctk.CTkOptionMenu(
             self,
             values=["Light", "Dark"],
@@ -73,11 +78,11 @@ class SettingsFrame(ctk.CTkFrame):
         except Exception:
             current = "Dark"
         self.appearance_option.set(current)
-        self.appearance_option.grid(row=7, column=1, sticky="ew", pady=(0,5))
+        self.appearance_option.grid(row=8, column=1, sticky="ew", pady=(0,5))
 
         self.grid_columnconfigure(1, weight=1)
 
-    def load_data(self, settings_data: dict, google_key: str, openai_key: str):
+    def load_data(self, settings_data: dict, google_key: str, openai_key: str, events_url: str):
         """Populate all fields, falling back to sensible defaults."""
         settings_data = settings_data or {}
         colors = settings_data.get("colors", {})
@@ -126,6 +131,10 @@ class SettingsFrame(ctk.CTkFrame):
         self.openai_api_entry.insert(0, openai_key or "")
         self.save_openai_key_callback(self.openai_api_entry.get())
 
+        self.events_feed_entry.delete(0, "end")
+        self.events_feed_entry.insert(0, events_url or "")
+        self.save_events_url_callback(self.events_feed_entry.get())
+
         # Fire a preview refresh
         self.refresh_callback()
 
@@ -141,6 +150,7 @@ class SettingsFrame(ctk.CTkFrame):
             },
             "google_api_key": self.google_api_entry.get(),
             "openai_api_key": self.openai_api_entry.get(),
+            "events_feed_url": self.events_feed_entry.get(),
             "appearance_mode": self.appearance_option.get(),
         }
 


### PR DESCRIPTION
## Summary
- load and save calendar feed URL in config
- expose feed URL in settings panel
- auto-sync events from configured feed on startup
- persist events feed URL in drafts
- mark roadmap item *Link Event Feed to Admin Calendar* complete

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688ab387d2f8832da5c08976d8f1ab31