### PR TITLE
Add recurring events handling

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -138,7 +138,7 @@
     "acceptance": "Events can be imported and previewed from a connected calendar feed with minimal setup."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Recurring Events Handling",
     "action": "Detect recurring events and allow user to select which occurrences to include.",
     "acceptance": "User can include only upcoming events or specific days from recurring schedules (e.g., Yoga every Tuesday)."

--- a/src/bulletin_builder/app_core/importer.py
+++ b/src/bulletin_builder/app_core/importer.py
@@ -3,7 +3,13 @@ import io
 import urllib.request
 from tkinter import filedialog, messagebox, simpledialog
 
-from ..event_feed import fetch_events, events_to_blocks, process_event_images
+from ..event_feed import (
+    fetch_events,
+    events_to_blocks,
+    process_event_images,
+    expand_recurring_event,
+)
+from ..ui.recurring_event_dialog import RecurringEventDialog
 
 
 def init(app):
@@ -69,6 +75,17 @@ def init(app):
             messagebox.showerror('Import Error', str(e))
             return
         events = events_to_blocks(raw_events)
+        expanded: list[dict] = []
+        bulletin_date = app.settings_frame.date_entry.get()
+        for ev in events:
+            occ = expand_recurring_event(ev, bulletin_date)
+            if len(occ) > 1:
+                dlg = RecurringEventDialog(app, occ)
+                selected = dlg.get_selected()
+                expanded.extend(selected)
+            else:
+                expanded.append(occ[0])
+        events = expanded
         process_event_images(events)
         if not events:
             messagebox.showinfo('Import Events', 'No events found.')

--- a/src/bulletin_builder/event_feed.py
+++ b/src/bulletin_builder/event_feed.py
@@ -5,6 +5,8 @@ import urllib.request
 import os
 import tempfile
 from typing import List, Dict
+from datetime import datetime, date, timedelta
+import re
 
 from .image_utils import optimize_image
 
@@ -97,4 +99,90 @@ def process_event_images(
             ev["image_url"] = opt_path
         except Exception:
             continue
+
+
+WEEKDAYS = [
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday",
+    "Sunday",
+]
+
+
+def _parse_date(value: str, default_year: int) -> date | None:
+    if not value:
+        return None
+    clean = value.split("-")[0].strip()
+    patterns = [
+        "%Y-%m-%d",
+        "%m/%d/%Y",
+        "%m/%d/%y",
+        "%B %d, %Y",
+        "%b %d, %Y",
+        "%A, %B %d, %Y",
+        "%A, %B %d",
+        "%B %d",
+        "%b %d",
+    ]
+    for fmt in patterns:
+        try:
+            dt = datetime.strptime(clean, fmt)
+            if "%Y" not in fmt:
+                dt = dt.replace(year=default_year)
+            return dt.date()
+        except ValueError:
+            continue
+    return None
+
+
+def _parse_recurring_day(text: str) -> str | None:
+    if not text:
+        return None
+    lower = text.strip().lower()
+    if re.search(r"every\s+day", lower):
+        return "daily"
+    for day in WEEKDAYS:
+        if day.lower() in lower and not any(ch.isdigit() for ch in lower):
+            return day
+    return None
+
+
+def expand_recurring_event(
+    event: Dict[str, str], bulletin_date: str = "", weeks: int = 4
+) -> List[Dict[str, str]]:
+    day = _parse_recurring_day(event.get("date", ""))
+    if not day:
+        return [event]
+
+    base = _parse_date(bulletin_date, datetime.today().year) or date.today()
+
+    occurrences: List[Dict[str, str]] = []
+    if day == "daily":
+        start = base
+        for i in range(weeks * 7):
+            dt = start + timedelta(days=i)
+            ev = event.copy()
+            ev["date"] = dt.strftime("%A, %B %d, %Y")
+            occurrences.append(ev)
+    else:
+        idx = WEEKDAYS.index(day)
+        start = base + timedelta((idx - base.weekday()) % 7)
+        for i in range(weeks):
+            dt = start + timedelta(days=i * 7)
+            ev = event.copy()
+            ev["date"] = dt.strftime("%A, %B %d, %Y")
+            occurrences.append(ev)
+    return occurrences
+
+
+def expand_recurring_events(
+    events: List[Dict[str, str]], bulletin_date: str = "", weeks: int = 4
+) -> List[Dict[str, str]]:
+    expanded: List[Dict[str, str]] = []
+    for ev in events:
+        expanded.extend(expand_recurring_event(ev, bulletin_date, weeks))
+    return expanded
 

--- a/src/bulletin_builder/ui/recurring_event_dialog.py
+++ b/src/bulletin_builder/ui/recurring_event_dialog.py
@@ -1,0 +1,46 @@
+import customtkinter as ctk
+import tkinter as tk
+
+
+class RecurringEventDialog(ctk.CTkToplevel):
+    """Dialog letting user choose which recurring event dates to include."""
+
+    def __init__(self, parent, occurrences):
+        super().__init__(parent)
+        self.title("Select Event Dates")
+        self.geometry("420x400")
+        self.transient(parent)
+        self.grab_set()
+        self.selected = []
+
+        frame = ctk.CTkScrollableFrame(self, label_text="Include dates:")
+        frame.pack(expand=True, fill="both", padx=20, pady=20)
+
+        self.vars = []
+        for occ in occurrences:
+            var = tk.BooleanVar(value=True)
+            desc = f"{occ.get('date', '')} {occ.get('time', '')} - {occ.get('description', '')}"
+            chk = ctk.CTkCheckBox(frame, text=desc, variable=var)
+            chk.pack(anchor="w", pady=2)
+            self.vars.append((var, occ))
+
+        btnf = ctk.CTkFrame(self)
+        btnf.pack(fill="x", side="bottom")
+        ctk.CTkButton(btnf, text="OK", command=self.on_ok).pack(side="right")
+        ctk.CTkButton(
+            btnf,
+            text="Cancel",
+            command=self.destroy,
+            fg_color="gray50",
+            hover_color="gray40",
+        ).pack(side="right", padx=(0, 10))
+
+        self.wait_window()
+
+    def on_ok(self):
+        self.selected = [ev for var, ev in self.vars if var.get()]
+        self.destroy()
+
+    def get_selected(self):
+        return self.selected
+


### PR DESCRIPTION
## Summary
- detect weekly/daily recurring events when importing
- prompt user to select which dates to include
- add RecurringEventDialog UI component
- mark recurring events roadmap item complete

## Testing
- `pytest -q`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688ab54ff054832da894df159bc94ede