### PR TITLE
Add section recommender suggestions

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -144,7 +144,7 @@
     "acceptance": "User can include only upcoming events or specific days from recurring schedules (e.g., Yoga every Tuesday)."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Bulletin Section Recommender AI",
     "action": "Based on the imported events, suggest sections such as 'Top Picks', 'Kids Events', 'Live Music', etc.",
     "acceptance": "User sees smart prompts to categorize event content and can accept or modify sections."

--- a/src/bulletin_builder/app_core/suggestions.py
+++ b/src/bulletin_builder/app_core/suggestions.py
@@ -1,5 +1,6 @@
 import customtkinter as ctk
 import tkinter as tk
+import re
 
 
 def init(app):
@@ -26,19 +27,55 @@ def init(app):
 
     def compute_suggestions():
         suggestions = []
+        app.section_recommendations = {}
+
         events_sections = [
             sec
             for sec in app.sections_data
             if sec.get("type") in ("events", "lacc_events", "community_events")
         ]
-        total_events = sum(len(sec.get("content", [])) for sec in events_sections)
+
+        all_events = []
+        for sec in events_sections:
+            all_events.extend(sec.get("content", []))
+
+        total_events = len(all_events)
         has_highlights = any(
             "Community Highlights" in sec.get("title", "") for sec in app.sections_data
         )
+
         if total_events >= 5 and not has_highlights:
             suggestions.append("Add a 'Community Highlights' banner")
+
+        # --- Simple AI-style recommendations for event categories ---
+        categories = {
+            "Kids Events": [
+                ev
+                for ev in all_events
+                if re.search(r"\b(kids?|family|child)\b", ev.get("description", ""), re.I)
+            ],
+            "Live Music": [
+                ev
+                for ev in all_events
+                if re.search(r"\b(concert|music|band|live music)\b", ev.get("description", ""), re.I)
+            ],
+        }
+
+        if all_events:
+            categories.setdefault("Top Picks", all_events[: min(3, len(all_events))])
+
+        for title, evs in categories.items():
+            if not evs:
+                continue
+            if any(title.lower() in sec.get("title", "").lower() for sec in app.sections_data):
+                continue
+            label = f"Add '{title}' section ({len(evs)} events)"
+            suggestions.append(label)
+            app.section_recommendations[label] = (title, evs)
+
         if not suggestions:
             suggestions.append("No suggestions")
+
         app.suggestions_list.delete(0, tk.END)
         for s in suggestions:
             app.suggestions_list.insert(tk.END, s)
@@ -48,7 +85,20 @@ def init(app):
         if not sel:
             return
         suggestion = app.suggestions_list.get(sel[0])
-        if "Community Highlights" in suggestion:
+        if suggestion in getattr(app, "section_recommendations", {}):
+            title, events = app.section_recommendations[suggestion]
+            app.sections_data.append(
+                {
+                    "title": title,
+                    "type": "community_events",
+                    "content": events,
+                    "layout_style": "Card",
+                }
+            )
+            app.refresh_listbox_titles()
+            app.show_placeholder()
+            app.update_preview()
+        elif "Community Highlights" in suggestion:
             app.sections_data.append(
                 {
                     "title": "Community Highlights",


### PR DESCRIPTION
## Summary
- provide simple keyword-based event section recommendations
- allow applying recommended sections from suggestions panel
- mark Section Recommender AI roadmap item complete

## Testing
- `python -m compileall -q src`
- `pip install pylint` *(fails: Tunnel connection failed)*
- `pylint $(git ls-files '*.py')` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688b906be71c832db8c8adf435e82b2a