### PR TITLE
Add event tagging and filtering

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -150,7 +150,7 @@
     "acceptance": "User sees smart prompts to categorize event content and can accept or modify sections."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "User-Defined Event Tags and Filtering",
     "action": "Allow custom tags (e.g., 'Family', 'Free', 'Concert') for events and enable filtering during import.",
     "acceptance": "User can filter events by tag and group them visually in the bulletin."

--- a/src/bulletin_builder/app_core/importer.py
+++ b/src/bulletin_builder/app_core/importer.py
@@ -89,6 +89,22 @@ def init(app):
                 allowed = {d.strip() for d in resp.split(',') if d.strip()}
                 raw_events = [ev for ev in raw_events if ev.get('date') in allowed]
 
+        # Prompt for tags if available
+        tags_set = set(t for ev in raw_events for t in (ev.get('tags') or []))
+        if tags_set:
+            tag_prompt = (
+                "Available tags:\n"
+                + ", ".join(sorted(tags_set))
+                + "\nEnter tags to include (comma separated) or leave blank for all:"
+            )
+            resp = simpledialog.askstring('Select Tags', tag_prompt)
+            if resp:
+                allowed_tags = {t.strip().lower() for t in resp.split(',') if t.strip()}
+                raw_events = [
+                    ev for ev in raw_events
+                    if allowed_tags.intersection({t.lower() for t in (ev.get('tags') or [])})
+                ]
+
         events = events_to_blocks(raw_events)
         process_event_images(events)
         if not events:

--- a/src/bulletin_builder/bulletin_renderer.py
+++ b/src/bulletin_builder/bulletin_renderer.py
@@ -35,8 +35,9 @@ class BulletinRenderer:
             text or "", output_format="html"
         )
 
-        # Register event grouping filter
+        # Register event grouping filters
         self.env.filters["group_events"] = self._group_events
+        self.env.filters["group_events_by_tag"] = self._group_events_by_tag
 
     # --- Event Grouping Logic -------------------------------------------------
     def _parse_date(self, value: str, default_year: int) -> date | None:
@@ -94,6 +95,18 @@ class BulletinRenderer:
             grp = groups.setdefault(header, {"header": header, "events": []})
             grp["events"].append(ev)
 
+        return list(groups.values())
+
+    def _group_events_by_tag(self, events: List[Dict[str, str]]) -> List[Dict[str, object]]:
+        """Group events by their first tag."""
+        groups: OrderedDict[str, Dict[str, object]] = OrderedDict()
+        for ev in events:
+            tags = ev.get("tags") or []
+            if isinstance(tags, str):
+                tags = [t.strip() for t in tags.split(",") if t.strip()]
+            tag = tags[0] if tags else "Other"
+            grp = groups.setdefault(tag.capitalize(), {"header": tag.capitalize(), "events": []})
+            grp["events"].append(ev)
         return list(groups.values())
 
     def set_template(self, name: str):

--- a/src/bulletin_builder/templates/partials/events.html
+++ b/src/bulletin_builder/templates/partials/events.html
@@ -4,8 +4,10 @@
 {% endif %}
 
 {% if section.content %}
-    {% for group in section.content | group_events(settings.bulletin_date) %}
-        <h3>{{ group.header }}</h3>
+    {% for tag_group in section.content | group_events_by_tag %}
+        <h3>{{ tag_group.header }}</h3>
+        {% for group in tag_group.events | group_events(settings.bulletin_date) %}
+            <h4>{{ group.header }}</h4>
         {% if section.layout_style == 'Grid' %}
         <table cellpadding="0" cellspacing="0" width="100%" style="border-collapse: collapse; font-size: 0;">
             {% for row in group.events|batch(2) %}
@@ -60,6 +62,7 @@
             {% endfor %}
         </table>
         {% endif %}
+        {% endfor %}
     {% endfor %}
 {% else %}
     <p>No events scheduled.</p>


### PR DESCRIPTION
## Summary
- support event tags throughout event pipeline
- allow tag-based filtering during event import
- group imported events by tag in rendered bulletins
- mark "User-Defined Event Tags and Filtering" roadmap item complete

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b96d457dc832d857dfdfd130abd11