### PR TITLE
Implement event conflict detection

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -156,7 +156,7 @@
     "acceptance": "User can filter events by tag and group them visually in the bulletin."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Event Conflict Detection",
     "action": "Analyze times of imported events and flag overlaps or double-bookings to the user.",
     "acceptance": "User is alerted when two events share overlapping time slots and can adjust layout accordingly."

--- a/src/bulletin_builder/app_core/importer.py
+++ b/src/bulletin_builder/app_core/importer.py
@@ -8,6 +8,7 @@ from ..event_feed import (
     events_to_blocks,
     process_event_images,
     expand_recurring_events,
+    detect_conflicts,
 )
 
 
@@ -107,6 +108,15 @@ def init(app):
 
         events = events_to_blocks(raw_events)
         process_event_images(events)
+        conflicts = detect_conflicts(events)
+        if conflicts:
+            msg_lines = ["Overlapping events detected:"]
+            for a, b in conflicts:
+                msg_lines.append(
+                    f"- {a.get('description','')} ({a.get('date')} {a.get('time')}) \u2194 "
+                    f"{b.get('description','')} ({b.get('date')} {b.get('time')})"
+                )
+            messagebox.showwarning('Event Conflicts', '\n'.join(msg_lines))
         if not events:
             messagebox.showinfo('Import Events', 'No events found.')
             return


### PR DESCRIPTION
## Summary
- detect overlapping events when importing feeds
- warn user about conflicts in importer
- update roadmap

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688b996cc5e8832db4faf96f897ad3c3