### PR TITLE
Implement event link and map buttons

### DIFF
--- a/roadmap.json
+++ b/roadmap.json
@@ -162,7 +162,7 @@
     "acceptance": "User is alerted when two events share overlapping time slots and can adjust layout accordingly."
   },
   {
-    "status": "todo",
+    "status": "complete",
     "title": "Add Event Link + Map Button Support",
     "action": "Each event block supports adding an external link (to website or map). Auto-format as a styled button.",
     "acceptance": "User can click a 'View Map' or 'More Info' button on each event block."

--- a/src/bulletin_builder/event_feed.py
+++ b/src/bulletin_builder/event_feed.py
@@ -34,8 +34,8 @@ def fetch_events(url: str) -> List[Dict[str, str]]:
             title/description, date, time, image or image_url.
 
     Returns:
-        A list of event dictionaries with ``date``, ``time``, ``description`` and
-        ``image_url`` keys.
+        A list of event dictionaries with ``date``, ``time``, ``description``,
+        ``image_url``, ``link`` and ``map_link`` keys.
     """
     with urllib.request.urlopen(url) as resp:
         text = resp.read().decode("utf-8")
@@ -53,6 +53,8 @@ def fetch_events(url: str) -> List[Dict[str, str]]:
                     "description": item.get("title") or item.get("description", ""),
                     "image_url": item.get("image") or item.get("image_url", ""),
                     "tags": _normalize_tags(item.get("tags") or item.get("categories") or item.get("labels") or item.get("tag")),
+                    "link": item.get("link") or item.get("url", ""),
+                    "map_link": item.get("map") or item.get("map_link", ""),
                 }
             )
     except json.JSONDecodeError:
@@ -65,6 +67,8 @@ def fetch_events(url: str) -> List[Dict[str, str]]:
                     "description": row.get("title") or row.get("description", ""),
                     "image_url": row.get("image") or row.get("image_url", ""),
                     "tags": _normalize_tags(row.get("tags") or row.get("categories") or row.get("labels") or row.get("tag")),
+                    "link": row.get("link") or row.get("url", ""),
+                    "map_link": row.get("map") or row.get("map_link", ""),
                 }
             )
     return [e for e in events if any(e.values())]
@@ -86,6 +90,8 @@ def events_to_blocks(events: List[Dict[str, str]]) -> List[Dict[str, str]]:
                 "description": (ev.get("description") or ev.get("title") or "").strip(),
                 "image_url": (ev.get("image_url") or ev.get("image") or "").strip(),
                 "tags": _normalize_tags(ev.get("tags")),
+                "link": (ev.get("link") or ev.get("url") or "").strip(),
+                "map_link": (ev.get("map_link") or ev.get("map") or "").strip(),
             }
         )
     return blocks

--- a/src/bulletin_builder/templates/partials/events.html
+++ b/src/bulletin_builder/templates/partials/events.html
@@ -28,6 +28,18 @@
                                 <span style="font-size: 0.9em; color: #666;">{{ event.date }} {% if event.time %}at {{ event.time }}{% endif %}</span>
                             </td>
                         </tr>
+                        {% if event.link or event.map_link %}
+                        <tr>
+                            <td style="border: none; padding: 5px 0; text-align: center;">
+                                {% if event.link %}
+                                <a href="{{ event.link }}" target="_blank" style="display:inline-block; background-color: {{ settings.colors.primary or '#1F6AA5' }}; color:#fff; padding:6px 12px; border-radius:4px; text-decoration:none; margin-right:5px;">More Info</a>
+                                {% endif %}
+                                {% if event.map_link %}
+                                <a href="{{ event.map_link }}" target="_blank" style="display:inline-block; background-color: {{ settings.colors.primary or '#1F6AA5' }}; color:#fff; padding:6px 12px; border-radius:4px; text-decoration:none;">View Map</a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endif %}
                     </table>
                 </td>
                 {% endfor %}
@@ -56,6 +68,18 @@
                                 <span style="font-size: 1em; color: {{ settings.colors.primary or '#005f73' }}; font-weight: bold;">{{ event.date }} {% if event.time %}at {{ event.time }}{% endif %}</span>
                             </td>
                         </tr>
+                        {% if event.link or event.map_link %}
+                        <tr>
+                            <td style="border: none; padding: 0 20px 20px 20px; text-align: center;">
+                                {% if event.link %}
+                                <a href="{{ event.link }}" target="_blank" style="display:inline-block; background-color: {{ settings.colors.primary or '#1F6AA5' }}; color:#fff; padding:6px 12px; border-radius:4px; text-decoration:none; margin-right:5px;">More Info</a>
+                                {% endif %}
+                                {% if event.map_link %}
+                                <a href="{{ event.map_link }}" target="_blank" style="display:inline-block; background-color: {{ settings.colors.primary or '#1F6AA5' }}; color:#fff; padding:6px 12px; border-radius:4px; text-decoration:none;">View Map</a>
+                                {% endif %}
+                            </td>
+                        </tr>
+                        {% endif %}
                     </table>
                 </td>
             </tr>

--- a/src/bulletin_builder/ui/events.py
+++ b/src/bulletin_builder/ui/events.py
@@ -100,14 +100,35 @@ class EventsFrame(ctk.CTkFrame):
         image_url_frame = ctk.CTkFrame(entry_frame, fg_color="transparent")
         image_url_frame.grid(row=1, column=0, sticky="ew", pady=5)
         image_url_frame.grid_columnconfigure(0, weight=1)
-        
+
         image_url_entry = ctk.CTkEntry(image_url_frame, placeholder_text="Image URL (optional)")
         image_url_entry.grid(row=0, column=0, padx=5, pady=5, sticky="ew")
         image_url_entry.insert(0, event_item_data.get("image_url", ""))
         image_url_entry.bind("<KeyRelease>", lambda e, i=index: self.update_event_data(i, "image_url", e.widget.get()))
 
+        link_frame = ctk.CTkFrame(entry_frame, fg_color="transparent")
+        link_frame.grid(row=2, column=0, sticky="ew", pady=5)
+        link_frame.grid_columnconfigure(0, weight=1)
+
+        link_entry = ctk.CTkEntry(link_frame, placeholder_text="More Info Link (optional)")
+        link_entry.grid(row=0, column=0, padx=5, pady=5, sticky="ew")
+        link_entry.insert(0, event_item_data.get("link", ""))
+        link_entry.bind("<KeyRelease>", lambda e, i=index: self.update_event_data(i, "link", e.widget.get()))
+
+        map_entry = ctk.CTkEntry(link_frame, placeholder_text="Map Link (optional)")
+        map_entry.grid(row=1, column=0, padx=5, pady=5, sticky="ew")
+        map_entry.insert(0, event_item_data.get("map_link", ""))
+        map_entry.bind("<KeyRelease>", lambda e, i=index: self.update_event_data(i, "map_link", e.widget.get()))
+
     def add_event_item(self):
-        self.section_data['content'].append({"date": "", "time": "", "description": "", "image_url": ""})
+        self.section_data['content'].append({
+            "date": "",
+            "time": "",
+            "description": "",
+            "image_url": "",
+            "link": "",
+            "map_link": "",
+        })
         self.rebuild_event_list()
         self._on_data_change()
 


### PR DESCRIPTION
## Summary
- allow entering links for event items in the editor
- parse `link` and `map_link` values when importing events
- render "More Info" and "View Map" buttons in events template
- mark roadmap item as complete

## Testing
- `pylint $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_688b9ad93670832dbacb5a5188eca475